### PR TITLE
Ensure links to meetings render as html links.

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,6 @@ func main() {
 	// Output confluence markup format
 	fmt.Println("||Name||Date and Time||Meeting Recording URL||")
 	for _, v := range data {
-		fmt.Printf("|%s|%s|%s|\n", v[0], v[1], v[2])
+		fmt.Printf("|%s|%s|[%s]|\n", v[0], v[1], v[2])
 	}
 }


### PR DESCRIPTION
Added a tiny bit of markup so meeting links render as links. I think this should work but please test as I am not able to do that with out setting up API access to Zoom and Confluence.